### PR TITLE
Support escaped_fragment with push-state URLs

### DIFF
--- a/prerender.go
+++ b/prerender.go
@@ -90,7 +90,7 @@ func (p *Prerender) ShouldPrerender(or *http.Request) bool {
 	}
 
 	// Buffer Agent or requesting an excaped fragment, request prerender
-	if bufferAgent != "" || or.URL.Query().Get("_escaped_fragment_") != "" {
+	if _, ok := or.URL.Query()["_escaped_fragment_"]; bufferAgent != "" || ok {
 		isRequestingPrerenderedPage = true
 	}
 


### PR DESCRIPTION
This change is needed to support URLs with push-state such as:
  http://localhost:3000/profiles/1234?_escaped_fragment_=

Push-state URLs are recommended in [the documentation on prerender.io](https://prerender.io/documentation) and supported by [prerender-node](https://github.com/prerender/prerender-node#testing).