### PR TITLE
Synced with prerender-node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/vishr/prerender
+
+go 1.13
+
+require (
+	github.com/jqatampa/gadget-arm v0.0.0-20180515205159-afcca8d2e871
+	google.golang.org/appengine v1.6.5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
+github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/jqatampa/gadget-arm v0.0.0-20180515205159-afcca8d2e871 h1:NTi9vT4le+CLv/I47JVhlczZ7X9vkJZ6FtsKjSpQP1s=
+github.com/jqatampa/gadget-arm v0.0.0-20180515205159-afcca8d2e871/go.mod h1:zmzDcVlJLlhptjSPlMIAKL2Kwws51A9obJUfFKOTvd4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65 h1:+rhAzEzT3f4JtomfC371qB+0Ola2caSKcY69NUBZrRQ=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
+google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/prerender.go
+++ b/prerender.go
@@ -33,10 +33,10 @@ type Options struct {
 func NewOptions() *Options {
 	url, _ := url.Parse("https://service.prerender.io/")
 	return &Options{
-		PrerenderURL: url,
-		Token:        os.Getenv("PRERENDER_TOKEN"),
-		BlackList:    nil,
-		WhiteList:    nil,
+		PrerenderURL:   url,
+		Token:          os.Getenv("PRERENDER_TOKEN"),
+		BlackList:      nil,
+		WhiteList:      nil,
 		UsingAppEngine: false,
 	}
 }
@@ -93,7 +93,7 @@ func (p *Prerender) ShouldPrerender(or *http.Request) bool {
 
 	// Cralwer, request prerender
 	for _, crawlerAgent := range crawlerUserAgents {
-		if strings.Contains(crawlerAgent, strings.ToLower(userAgent)) {
+		if strings.Contains(strings.ToLower(userAgent), strings.ToLower(crawlerAgent)) {
 			isRequestingPrerenderedPage = true
 			break
 		}

--- a/variables.go
+++ b/variables.go
@@ -5,6 +5,10 @@ import "regexp"
 var cfSchemeRegex = regexp.MustCompile("\"scheme\":\"(http|https)\"")
 
 var crawlerUserAgents = [...]string{
+	"googlebot",
+	"Yahoo! Slurp",
+	"bingbot",
+	"yandex",
 	"baiduspider",
 	"facebookexternalhit",
 	"twitterbot",
@@ -14,9 +18,26 @@ var crawlerUserAgents = [...]string{
 	"quora link preview",
 	"showyoubot",
 	"outbrain",
-	"pinterest",
+	"pinterest/0.",
 	"developers.google.com/+/web/snippet",
 	"slackbot",
+	"vkShare",
+	"W3C_Validator",
+	"redditbot",
+	"Applebot",
+	"WhatsApp",
+	"flipboard",
+	"tumblr",
+	"bitlybot",
+	"SkypeUriPreview",
+	"nuzzel",
+	"Discordbot",
+	"Google Page Speed",
+	"Qwantify",
+	"pinterestbot",
+	"Bitrix link preview",
+	"XING-contenttabreceiver",
+	"Chrome-Lighthouse",
 }
 
 var skippedTypes = [...]string{
@@ -58,4 +79,8 @@ var skippedTypes = [...]string{
 	".flv",
 	".m4v",
 	".torrent",
+	".woff",
+	".ttf",
+	".svg",
+	".webmanifest",
 }


### PR DESCRIPTION
- Updated crawlers
- Swapped condition to check user-agent in crawlers e.g. earlier `facebookexternalhit/1.1` was failing.

Signed-off-by: Vishal Rana <vr@labstack.com>